### PR TITLE
refactor: Entity#isInWaterOrRain() を使用するように変更

### DIFF
--- a/src/main/java/net/stln/magitech/feature/tool/trait/PrecipitationTrait.java
+++ b/src/main/java/net/stln/magitech/feature/tool/trait/PrecipitationTrait.java
@@ -36,7 +36,7 @@ public class PrecipitationTrait extends Trait {
 
     @Override
     public boolean effectEnabled(Player player, Level level, ItemStack stack, int traitLevel, ToolProperties properties) {
-        return player.isInWater() || level.isRainingAt(player.blockPosition());
+        return player.isInWaterOrRain();
     }
 
     @Override


### PR DESCRIPTION
```
player.isInWater() || level.isRainingAt(player.blockPosition());
```
をトライデントに使用されているminecraft標準のAPI：
```
player.isInWaterOrRain();
```
に置き換えることで、一部のmodとの互換性が向上します。
(例：`L2Hostility`の`Ring of Ocean`は`Entity#isInRain()`を使用しています：[link](https://github.com/Minecraft-LightLand/L2Hostility/blob/1.21/src/main/java/dev/xkmc/l2hostility/mixin/EntityMixin.java#L31))

通常環境での動作には影響しません。